### PR TITLE
Fix missing blip z coord and wrong error message

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -113,7 +113,7 @@ RegisterNetEvent('WRepair:repairWeaponItem', function(data)
     else
         lib.notify({
             title = 'Error',
-            description = 'You have repaired your weapon!',
+            description = 'You are missing a Self Weapon Kit!',
             position = 'top',
             duration = 3500,
             style = {
@@ -129,7 +129,7 @@ end)
 CreateThread(function()
     for i=1, #Config.Peds, 1 do
         -- Blip
-        local blip = AddBlipForCoord(Config.Peds[i].x, Config.Peds[i].y)
+        local blip = AddBlipForCoord(Config.Peds[i].x, Config.Peds[i].y, Config.Peds[i].z)
         SetBlipSprite(blip, 110)
         SetBlipScale(blip, 0.7)
         SetBlipColour(blip, 0)


### PR DESCRIPTION
## Summary
- fix error notification text when self repair kit is missing
- pass z coordinate when creating repair station blips

## Testing
- `luac -p client.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c457d1d08327a7a5e61e0aa20d38